### PR TITLE
Suggest not to pagninate only "index.html"

### DIFF
--- a/lib/jekyll-paginate/pager.rb
+++ b/lib/jekyll-paginate/pager.rb
@@ -36,8 +36,13 @@ module Jekyll
         page_dir = File.dirname(File.expand_path(remove_leading_slash(page.path), config['source']))
         paginate_path = remove_leading_slash(config['paginate_path'])
         paginate_path = File.expand_path(paginate_path, config['source'])
-        page.name == 'index.html' &&
-          in_hierarchy(config['source'], page_dir, File.dirname(paginate_path))
+		if config['paginate_page'] == nil
+			page.name == 'index.html' &&
+				in_hierarchy(config['source'], page_dir, File.dirname(paginate_path))
+		else
+			page.name == config['paginate_page'] &&
+				in_hierarchy(config['source'], page_dir, File.dirname(paginate_path))
+		end
       end
 
       # Determine if the subdirectories of the two paths are the same relative to source


### PR DESCRIPTION
Manage a new config parameter called site.config['paginate_page'].
And to use it, a condition has been added in the pagination_candidate
method. If paginate_page is not set, index.html will be the paginated page.
