### PR TITLE
Filter out posts that have hidden: true in frontmatter

### DIFF
--- a/lib/jekyll-paginate/pagination.rb
+++ b/lib/jekyll-paginate/pagination.rb
@@ -39,6 +39,7 @@ module Jekyll
       #                   "next_page" => <Number> }}
       def paginate(site, page)
         all_posts = site.site_payload['site']['posts']
+        all_posts = all_posts.reject { |p| p['hidden'] }
         pages = Pager.calculate_pages(all_posts, site.config['paginate'].to_i)
         (1..pages).each do |num_page|
           pager = Pager.new(site, num_page, all_posts, pages)


### PR DESCRIPTION
We require the ability to have posts that are available via the URL, but are hidden in the paginated list.
