### PR TITLE
Fix Absolute permalinks break paginator when permalink is specified for index file #5

### DIFF
--- a/lib/jekyll-paginate/pagination.rb
+++ b/lib/jekyll-paginate/pagination.rb
@@ -43,7 +43,7 @@ module Jekyll
         (1..pages).each do |num_page|
           pager = Pager.new(site, num_page, all_posts, pages)
           if num_page > 1
-            newpage = Page.new(site, site.source, page.dir, page.name)
+            newpage = Page.new(site, site.source, source_to_file_path(page), page.name)
             newpage.data.delete('permalink')
             newpage.pager = pager
             newpage.dir = Pager.paginate_path(site, num_page)
@@ -79,6 +79,11 @@ module Jekyll
         end.sort do |one, two|
           two.path.size <=> one.path.size
         end.first
+      end
+
+      private
+      def source_to_file_path(page)
+        page.url_placeholders[:path] # meant to use page.instance_variable_get('@dir')
       end
 
     end

--- a/lib/jekyll-paginate/pagination.rb
+++ b/lib/jekyll-paginate/pagination.rb
@@ -43,11 +43,7 @@ module Jekyll
         (1..pages).each do |num_page|
           pager = Pager.new(site, num_page, all_posts, pages)
           if num_page > 1
-            newpage = Page.new(site, site.source, source_to_file_path(page), page.name)
-            newpage.data.delete('permalink')
-            newpage.pager = pager
-            newpage.dir = Pager.paginate_path(site, num_page)
-            site.pages << newpage
+            site.pages << build_paginated_page(site, page, pager)
           else
             page.pager = pager
           end
@@ -82,6 +78,13 @@ module Jekyll
       end
 
       private
+      def build_paginated_page(site, page, pager)
+        page = Page.new(site, site.source, source_to_file_path(page), page.name)
+        page.data.delete('permalink')
+        page.pager = pager
+        page.dir = Pager.paginate_path(site, pager.page)
+        page
+      end
       def source_to_file_path(page)
         page.url_placeholders[:path] # meant to use page.instance_variable_get('@dir')
       end

--- a/lib/jekyll-paginate/pagination.rb
+++ b/lib/jekyll-paginate/pagination.rb
@@ -44,6 +44,7 @@ module Jekyll
           pager = Pager.new(site, num_page, all_posts, pages)
           if num_page > 1
             newpage = Page.new(site, site.source, page.dir, page.name)
+            newpage.data.delete('permalink')
             newpage.pager = pager
             newpage.dir = Pager.paginate_path(site, num_page)
             site.pages << newpage

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -20,5 +20,11 @@ RSpec.describe(Jekyll::Paginate::Pagination) do
       rewrite_index("permalink: /")
       expect(site.pages.select {|page| page.url == "/"}.length).to eql(1)
     end
+
+    it "paginated pages should be generated from index file given parmalink not matched to source" do
+      rewrite_index("permalink: /posts/")
+      site
+      expect(File.read(File.join(dest_dir('page2'), 'index.html'))).to eql("body")
+    end
   end
 end

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+RSpec.describe(Jekyll::Paginate::Pagination) do
+
+  context "with absoulte permalink in index file" do
+    before(:each) do
+      @original_index_string = File.read(File.join(source_dir, 'index.html'))
+    end
+    after(:each) do
+      File.open(File.join(source_dir, 'index.html'), 'w') { |f| f.write(@original_index_string) }
+    end
+
+    def rewrite_index(frontmatter_string)
+      File.open(File.join(source_dir, 'index.html'), 'w') { |f| f.write("---\n#{frontmatter_string}\n---\nbody") }
+    end
+
+    let(:site) { build_site }
+
+    it "paginated pages should not use absoulte permalink from index file" do
+      rewrite_index("permalink: /")
+      expect(site.pages.select {|page| page.url == "/"}.length).to eql(1)
+    end
+  end
+end


### PR DESCRIPTION
There were two issues related to absolute permalink in index file.
1. Absolute permalink in index file is also set to paginated pages so they all have the same url. As a result, index page shows the last paginated page.
2. Paginator looks for index file based on permalink not source location. so if permalink is not matched to index file path then paginated pages become blank pages.

Since this is my first commit to a open-source project, let me know anything I have missed or can improve.

Thanks.