### PR TITLE
support to sort posts by modified date

### DIFF
--- a/lib/jekyll-paginate/pagination.rb
+++ b/lib/jekyll-paginate/pagination.rb
@@ -38,7 +38,7 @@ module Jekyll
       #                   "previous_page" => <Number>,
       #                   "next_page" => <Number> }}
       def paginate(site, page)
-        all_posts = sort_by_modified.reject { |post| post['hidden'] }
+        all_posts = sort_posts_by_modified.reject { |post| post['hidden'] }
         pages = Pager.calculate_pages(all_posts, site.config['paginate'].to_i)
         (1..pages).each do |num_page|
           pager = Pager.new(site, num_page, all_posts, pages)
@@ -54,7 +54,7 @@ module Jekyll
       end
 
       # sort the posts by modified date if site has the *sort_by_modified* config
-      def sort_by_modified
+      def sort_posts_by_modified
         if site.config['sort_by_modified']
           all_posts = site.site_payload['site']['posts'].sort { |a, b| b.modified <=> a.modified }
         else

--- a/lib/jekyll-paginate/pagination.rb
+++ b/lib/jekyll-paginate/pagination.rb
@@ -38,7 +38,7 @@ module Jekyll
       #                   "previous_page" => <Number>,
       #                   "next_page" => <Number> }}
       def paginate(site, page)
-        all_posts = site.site_payload['site']['posts'].reject { |post| post['hidden'] }
+        all_posts = sort_by_modified.reject { |post| post['hidden'] }
         pages = Pager.calculate_pages(all_posts, site.config['paginate'].to_i)
         (1..pages).each do |num_page|
           pager = Pager.new(site, num_page, all_posts, pages)
@@ -50,6 +50,15 @@ module Jekyll
           else
             page.pager = pager
           end
+        end
+      end
+
+      # sort the posts by modified date if site has the *sort_by_modified* config
+      def sort_by_modified
+        if site.config['sort_by_modified']
+          all_posts = site.site_payload['site']['posts'].sort { |a, b| b.modified <=> a.modified }
+        else
+          all_posts = site.site_payload['site']['posts']
         end
       end
 


### PR DESCRIPTION
Currently Jekyll sorts all posts by filename of post, this pull request wants to support to sort posts by modified date.

Once user updates his post and the value of **modified**, this post will be resort.
Case:
**created**
2015-08-31-post1.md
2015-09-02-post2.md

**updated**
+ modified 2015-08-31-post1.md
+ updated the value of `modified` in the post to be `2015-09-03`
Result:
The 2015-08-31-post1.md will be displayed before 2015-09-02-post2.md

**So all the latest updated post will be displayed on the first page.**
**Please take this into consideration**