### PR TITLE
Update for Jekyll 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
+- 2.2
 - 2.1
 - 2.0
 - 1.9.3
@@ -18,3 +19,18 @@ notifications:
   email:
     on_success: never
     on_failure: never
+
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      env: JEKYLL_VERSION=3.0.0
+    - env: JEKYLL_VERSION=2.4
+      rvm: 2.1
+    - rvm: 2.2
+      env: JEKYLL_VERSION=2.4
+
+env:
+  matrix:
+    - ""
+    - JEKYLL_VERSION=2.4
+    - JEKYLL_VERSION=3.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in jekyll-paginate.gemspec
 gemspec
+
+if ENV["JEKYLL_VERSION"]
+  gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}"
+end

--- a/jekyll-paginate.gemspec
+++ b/jekyll-paginate.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "jekyll", ">= 2.0"
+  spec.add_development_dependency "jekyll", ">= 2.0", "< 3.0"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/pager_spec.rb
+++ b/spec/pager_spec.rb
@@ -15,7 +15,12 @@ RSpec.describe(Jekyll::Paginate::Pager) do
     let(:site) { build_site }
 
     it "determines the correct pagination path for each page" do
-      expect(described_class.paginate_path(site, 1)).to eql("/index.html")
+      if Jekyll::VERSION < '3.0.0'
+        expect(described_class.paginate_path(site, 1)).to eql("/index.html")
+      else
+        expect(described_class.paginate_path(site, 1)).to eql("/")
+      end
+
       expect(described_class.paginate_path(site, 2)).to eql("/page2")
     end
   end
@@ -24,7 +29,12 @@ RSpec.describe(Jekyll::Paginate::Pager) do
     let(:site) { build_site({'paginate_path' => '/blog/page-:num'}) }
 
     it "determines the correct pagination path for each page" do
-      expect(described_class.paginate_path(site, 1)).to eql("/index.html")
+      if Jekyll::VERSION < '3.0.0'
+        expect(described_class.paginate_path(site, 1)).to eql("/index.html")
+      else
+        expect(described_class.paginate_path(site, 1)).to eql("/")
+      end
+
       expect(described_class.paginate_path(site, 2)).to eql("/blog/page-2")
     end
   end
@@ -33,7 +43,12 @@ RSpec.describe(Jekyll::Paginate::Pager) do
     let(:site) { build_site({'paginate_path' => '/blog/page/:num'}) }
 
     it "determines the correct pagination path for each page" do
-      expect(described_class.paginate_path(site, 1)).to eql("/index.html")
+      if Jekyll::VERSION < '3.0.0'
+        expect(described_class.paginate_path(site, 1)).to eql("/index.html")
+      else
+        expect(described_class.paginate_path(site, 1)).to eql("/")
+      end
+
       expect(described_class.paginate_path(site, 2)).to eql("/blog/page/2")
     end
   end
@@ -42,7 +57,12 @@ RSpec.describe(Jekyll::Paginate::Pager) do
     let(:site) { build_site({'paginate_path' => '/contacts/page:num'}) }
 
     it "determines the correct pagination path for each page" do
-      expect(described_class.paginate_path(site, 1)).to eql("/contacts/index.html")
+      if Jekyll::VERSION < '3.0.0'
+        expect(described_class.paginate_path(site, 1)).to eql("/contacts/index.html")
+      else
+        expect(described_class.paginate_path(site, 1)).to eql("/contacts/")
+      end
+
       expect(described_class.paginate_path(site, 2)).to eql("/contacts/page2")
     end
   end
@@ -51,7 +71,12 @@ RSpec.describe(Jekyll::Paginate::Pager) do
     let(:site) { build_site({'paginate_path' => '/contacts/page/:num'}) }
 
     it "determines the correct pagination path for each page" do
-      expect(described_class.paginate_path(site, 1)).to eql("/contacts/index.html")
+      if Jekyll::VERSION < '3.0.0'
+        expect(described_class.paginate_path(site, 1)).to eql("/contacts/index.html")
+      else
+        expect(described_class.paginate_path(site, 1)).to eql("/contacts/")
+      end
+
       expect(described_class.paginate_path(site, 2)).to eql("/contacts/page/2")
     end
   end
@@ -74,15 +99,23 @@ RSpec.describe(Jekyll::Paginate::Pager) do
 
   context "pagination enabled for 2" do
     let(:site)  { build_site('paginate' => 2) }
-    let(:posts) { site.posts }
+    if Jekyll::VERSION < '3.0.0'
+      let(:posts) { site.posts }
+    else
+      let(:posts) { site.posts.docs }
+    end
 
     it "report that pagination is enabled" do
       expect(described_class.pagination_enabled?(site)).to be_truthy
     end
-
+  
     context "with 4 posts" do
-      let(:posts) { site.posts[1..4] }
-
+      if Jekyll::VERSION < '3.0.0'
+        let(:posts) { site.posts[1..4] }
+      else
+        let(:posts) { site.posts.docs[1..4] }
+      end
+  
       it "create first pager" do
         pager = described_class.new(site, 1, posts)
         expect(pager.posts.size).to eql(2)
@@ -90,7 +123,7 @@ RSpec.describe(Jekyll::Paginate::Pager) do
         expect(pager.previous_page).to be_nil
         expect(pager.next_page).to eql(2)
       end
-
+  
       it "create second pager" do
         pager = described_class.new(site, 2, posts)
         expect(pager.posts.size).to eql(2)
@@ -98,16 +131,19 @@ RSpec.describe(Jekyll::Paginate::Pager) do
         expect(pager.previous_page).to eql(1)
         expect(pager.next_page).to be_nil
       end
-
+  
       it "not create third pager" do
         expect { described_class.new(site, 3, posts) }.to raise_error
       end
-
     end
 
     context "with 5 posts" do
-      let(:posts) { site.posts[1..5] }
-
+      if Jekyll::VERSION < '3.0.0'
+        let(:posts) { site.posts[1..5] }
+      else
+        let(:posts) { site.posts.docs[1..5] }
+      end
+  
       it "create first pager" do
         pager = described_class.new(site, 1, posts)
         expect(pager.posts.size).to eql(2)
@@ -115,7 +151,7 @@ RSpec.describe(Jekyll::Paginate::Pager) do
         expect(pager.previous_page).to be_nil
         expect(pager.next_page).to eql(2)
       end
-
+  
       it "create second pager" do
         pager = described_class.new(site, 2, posts)
         expect(pager.posts.size).to eql(2)
@@ -123,7 +159,7 @@ RSpec.describe(Jekyll::Paginate::Pager) do
         expect(pager.previous_page).to eql(1)
         expect(pager.next_page).to eql(3)
       end
-
+  
       it "create third pager" do
         pager = described_class.new(site, 3, posts)
         expect(pager.posts.size).to eql(1)
@@ -131,7 +167,7 @@ RSpec.describe(Jekyll::Paginate::Pager) do
         expect(pager.previous_page).to eql(2)
         expect(pager.next_page).to be_nil
       end
-
+  
       it "not create fourth pager" do
         expect { described_class.new(site, 4, posts) }.to raise_error(RuntimeError)
       end


### PR DESCRIPTION
As noted in jekyll/jekyll/issues/3945,

There was a need to run tests of selected gems against Jekyll 3. So I opted to try jekyll-paginate and see how it worked out.

Fortunately, the tests seem to be failing only against Jekyll 3 and not other version of Ruby. So it's just a deprecation issue. I'm going to want to rebase once I am done. As I am still learning Ruby, anyone that has some advice is welcome to help. I will take another look at this tomorrow.