### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
       - name: Execute tests
-        run:  bundle exec rspec
+        run:  'bundle exec rspec && true'
 
   style_check:
     if: "!contains(github.event.commits[0].message, '[ci skip]')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,4 +101,4 @@ jobs:
           ruby-version: ${{ matrix.ruby_version }}
           bundler-cache: true
       - name: Test Gem build
-        run:  bundle exec gem build jekyll-seo-tag.gemspec
+        run:  bundle exec gem build jekyll-paginate.gemspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  j4:
+    if: "!contains(github.event.commits[0].message, '[ci skip]')"
+    name: "Jekyll ${{ matrix.jekyll_version }} (Ruby ${{ matrix.ruby_version }})"
+    runs-on: 'ubuntu-latest'
+    env:
+      JEKYLL_VERSION: ${{ matrix.jekyll_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+        - 2.5
+        - 2.7
+        - 3.0
+        jekyll_version:
+        - "~> 3.0"
+        - "~> 4.0"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 5
+      - name: "Set up Ruby ${{ matrix.ruby_version }}"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - name: Execute tests
+        run:  bundle exec rspec
+  j3:
+    if: "!contains(github.event.commits[0].message, '[ci skip]')"
+    name: "Jekyll ${{ matrix.jekyll_version }} (Ruby ${{ matrix.ruby_version }})"
+    runs-on: 'ubuntu-latest'
+    env:
+      JEKYLL_VERSION: ${{ matrix.jekyll_version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+        - 2.5
+        jekyll_version:
+        - "~> 3.9"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 5
+      - name: "Set up Ruby ${{ matrix.ruby_version }}"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - name: Execute tests
+        run:  bundle exec rspec
+
+  style_check:
+    if: "!contains(github.event.commits[0].message, '[ci skip]')"
+    name: "Code Style Check (Ruby ${{ matrix.ruby_version }})"
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+        - 2.5
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 5
+      - name: "Set up Ruby ${{ matrix.ruby_version }}"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - name: Check Style Offenses
+        run:  bundle exec rubocop -S -D
+
+  gem_build:
+    if: "!contains(github.event.commits[0].message, '[ci skip]')"
+    name: "Test Gem build (Ruby ${{ matrix.ruby_version }})"
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+        - 2.5
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 5
+      - name: "Set up Ruby ${{ matrix.ruby_version }}"
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+          bundler-cache: true
+      - name: Test Gem build
+        run:  bundle exec gem build jekyll-seo-tag.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 if ENV["JEKYLL_VERSION"]
-  gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}"
+  gem "jekyll", ENV["JEKYLL_VERSION"]
 end

--- a/jekyll-paginate.gemspec
+++ b/jekyll-paginate.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "jekyll", ">= 2.0", "< 3.0"
+  spec.add_development_dependency "jekyll", ">= 2.0", "< 5.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/jekyll-paginate.gemspec
+++ b/jekyll-paginate.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop-jekyll"
 end


### PR DESCRIPTION
To pass, we need to allow Jekyll v3 and v4 as a development dependency.